### PR TITLE
Feat/multitag simple

### DIFF
--- a/anchor_autocalibrate/anchor_autocalibrate.ino
+++ b/anchor_autocalibrate/anchor_autocalibrate.ino
@@ -60,7 +60,8 @@ void setup()
 
   //start the module as anchor, don't assign random short address
   //DW1000Ranging.startAsAnchor(this_anchor_addr, DW1000.MODE_LONGDATA_FAST_ACCURACY, false);
-  DW1000Ranging.startAsAnchor(this_anchor_addr, DW1000.MODE_LONGDATA_RANGE_LOWPOWER, false);
+  // DW1000Ranging.startAsAnchor(this_anchor_addr, DW1000.MODE_LONGDATA_RANGE_LOWPOWER, false);
+  DW1000Ranging.startAsAnchor(this_anchor_addr, DW1000.MODE_LONGDATA_FAST_LOWPOWER, false);
   // DW1000Ranging.startAsAnchor(ANCHOR_ADD, DW1000.MODE_SHORTDATA_FAST_LOWPOWER);
   // DW1000Ranging.startAsAnchor(ANCHOR_ADD, DW1000.MODE_LONGDATA_FAST_LOWPOWER);
   // DW1000Ranging.startAsAnchor(ANCHOR_ADD, DW1000.MODE_SHORTDATA_FAST_ACCURACY);

--- a/multitag_control_server.py
+++ b/multitag_control_server.py
@@ -28,7 +28,7 @@ def current_milli_time():
     return round(time.time() * 1000)
 
 # Define the UDP server's IP address and port
-server_ip = "192.168.0.4" 
+server_ip = "192.168.1.115" 
 server_port = 12345  # Replace with the port you want to listen on
 
 # Create a UDP socket
@@ -50,10 +50,10 @@ while True:
         data, (ip, port) = udp_socket.recvfrom(1024)
     except socket.timeout:
         print("Trying again!")
-        if previous_id is not None:
-            id = get_next_key(tag_address, previous_id)
-            ip, port = tag_address[id]
-            request_measurements(udp_socket, ip, port)
+        # if previous_id is not None:
+        #     id = get_next_key(tag_address, previous_id)
+        #     ip, port = tag_address[id]
+        #     request_measurements(udp_socket, ip, port)
         continue
     
     if not data:
@@ -84,8 +84,5 @@ while True:
         next_id = get_next_key(tag_address, id)
         next_ip, next_port = tag_address[next_id]
 
-        # before moving on to next tag, add small delay to allow for tag to finish any communication with anchors
-        time.sleep(0.05)
-        
         request_measurements(udp_socket, next_ip, next_port)
         previous_id = next_id

--- a/multitag_control_server.py
+++ b/multitag_control_server.py
@@ -84,5 +84,8 @@ while True:
         next_id = get_next_key(tag_address, id)
         next_ip, next_port = tag_address[next_id]
 
+        # before moving on to next tag, add small delay to allow for tag to finish any communication with anchors
+        time.sleep(0.05)
+        
         request_measurements(udp_socket, next_ip, next_port)
         previous_id = next_id

--- a/multitag_control_server.py
+++ b/multitag_control_server.py
@@ -1,5 +1,5 @@
 """
-
+Prototype server that handles multitag
 """
 
 import socket
@@ -17,7 +17,7 @@ def get_next_key(d, current_key):
 
 def request_measurements(socket, ip, port):
     addr = (ip, port)
-    msg = "1"
+    msg = "1" # or whatever message
     socket.sendto(msg, addr)
     print(f"Sent req msg to {ip}:{port}")
 

--- a/multitag_control_server.py
+++ b/multitag_control_server.py
@@ -28,7 +28,7 @@ def current_milli_time():
     return round(time.time() * 1000)
 
 # Define the UDP server's IP address and port
-server_ip = "192.168.0.3" 
+server_ip = "192.168.0.4" 
 server_port = 12345  # Replace with the port you want to listen on
 
 # Create a UDP socket
@@ -51,7 +51,8 @@ while True:
     except socket.timeout:
         print("Trying again!")
         if previous_id is not None:
-            ip, port = tag_address[previous_id]
+            id = get_next_key(tag_address, previous_id)
+            ip, port = tag_address[id]
             request_measurements(udp_socket, ip, port)
         continue
     

--- a/multitag_control_server.py
+++ b/multitag_control_server.py
@@ -1,5 +1,7 @@
 """
-Prototype server that handles multitag
+Prototype server that handles multitag.
+
+Tags needs to send an initial packet to register itself with the server.
 """
 
 import socket

--- a/multitag_control_server.py
+++ b/multitag_control_server.py
@@ -1,0 +1,64 @@
+"""
+
+"""
+
+import socket
+import time
+# Helper Functions
+
+# get next key of the dict, returns the first key if it reaches the end
+def get_next_key(d, current_key):
+    keys = list(d.keys())
+    if current_key not in keys:
+        raise ValueError("The provided key is not in the dictionary.")
+    current_index = keys.index(current_key)
+    next_index = (current_index + 1) % len(keys)
+    return keys[next_index]
+
+def request_measurements(socket, ip, port):
+    addr = (ip, port)
+    msg = "1"
+    socket.sendto(msg, addr)
+    print(f"Sent req msg to {ip}:{port}")
+
+def current_milli_time():
+    return round(time.time() * 1000)
+
+# Define the UDP server's IP address and port
+server_ip = "192.168.0.219" 
+server_port = 12345  # Replace with the port you want to listen on
+
+# Create a UDP socket
+udp_socket = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+
+# Bind the socket to the specified IP address and port
+udp_socket.bind((server_ip, server_port))
+
+print(f"UDP server listening on {server_ip}:{server_port}")
+
+tag_address = {} # maps ip to port
+start_time = 0
+
+while True:
+    data, (ip, port) = udp_socket.recvfrom(1024)
+
+    # add to tag list if we haven't seen this tag before
+    if ip not in tag_address.keys():
+        print(f"New tag added. Address: {ip}:{port}")
+        tag_address[ip] = port
+        if len(tag_address) is 1:
+            request_measurements(udp_socket, ip, port)
+            start_time = current_milli_time()
+    # have seen this before, and just got back a packet.
+    else: 
+        print(f"Received {len(data)} bytes from {ip}:{port}")
+        print(f"Data: {data.decode('utf-8')}")
+        end_time = current_milli_time()
+        time_taken = end_time - start_time
+        print(f"Time taken (ms): {time_taken}")
+        start_time = current_milli_time()
+
+        next_ip = get_next_key(tag_address, ip)
+        next_port = tag_address[next_ip]
+
+        request_measurements(udp_socket, next_ip, next_port)

--- a/multitag_control_server.py
+++ b/multitag_control_server.py
@@ -27,7 +27,7 @@ def current_milli_time():
     return round(time.time() * 1000)
 
 # Define the UDP server's IP address and port
-server_ip = "192.168.0.219" 
+server_ip = "192.168.0.242" 
 server_port = 12345  # Replace with the port you want to listen on
 
 # Create a UDP socket

--- a/multitag_control_server.py
+++ b/multitag_control_server.py
@@ -48,7 +48,7 @@ while True:
     if ip not in tag_address.keys():
         print(f"New tag added. Address: {ip}:{port}")
         tag_address[ip] = port
-        if len(tag_address) is 1:
+        if len(tag_address) == 1:
             request_measurements(udp_socket, ip, port)
             start_time = current_milli_time()
     # have seen this before, and just got back a packet.

--- a/multitag_control_server.py
+++ b/multitag_control_server.py
@@ -6,6 +6,7 @@ Tags needs to send an initial packet to register itself with the server.
 
 import socket
 import time
+import json
 # Helper Functions
 
 # get next key of the dict, returns the first key if it reaches the end
@@ -19,7 +20,7 @@ def get_next_key(d, current_key):
 
 def request_measurements(socket, ip, port):
     addr = (ip, port)
-    msg = "1" # or whatever message
+    msg = bytes("1", 'utf-8') # or whatever message
     socket.sendto(msg, addr)
     print(f"Sent req msg to {ip}:{port}")
 
@@ -27,7 +28,7 @@ def current_milli_time():
     return round(time.time() * 1000)
 
 # Define the UDP server's IP address and port
-server_ip = "192.168.0.242" 
+server_ip = "192.168.0.212" 
 server_port = 12345  # Replace with the port you want to listen on
 
 # Create a UDP socket
@@ -35,6 +36,7 @@ udp_socket = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
 
 # Bind the socket to the specified IP address and port
 udp_socket.bind((server_ip, server_port))
+udp_socket.settimeout(1)
 
 print(f"UDP server listening on {server_ip}:{server_port}")
 
@@ -42,25 +44,34 @@ tag_address = {} # maps ip to port
 start_time = 0
 
 while True:
-    data, (ip, port) = udp_socket.recvfrom(1024)
+    try:
+        data, (ip, port) = udp_socket.recvfrom(1024)
+    except socket.timeout:
+        print("Trying again!")
+        continue
+    
+    if not data:
+        continue
 
+    data = json.loads(data.decode('utf-8'))
+    id = data['id']
     # add to tag list if we haven't seen this tag before
-    if ip not in tag_address.keys():
-        print(f"New tag added. Address: {ip}:{port}")
-        tag_address[ip] = port
+    if id not in tag_address.keys():  
+        print(f"New tag added. ID: {id} Address: {ip}:{port}")
+        tag_address[id] = (ip,port)
         if len(tag_address) == 1:
             request_measurements(udp_socket, ip, port)
             start_time = current_milli_time()
     # have seen this before, and just got back a packet.
     else: 
         print(f"Received {len(data)} bytes from {ip}:{port}")
-        print(f"Data: {data.decode('utf-8')}")
+        print(f"Data: {data}")
         end_time = current_milli_time()
         time_taken = end_time - start_time
         print(f"Time taken (ms): {time_taken}")
         start_time = current_milli_time()
 
-        next_ip = get_next_key(tag_address, ip)
-        next_port = tag_address[next_ip]
+        next_id = get_next_key(tag_address, id)
+        next_ip, next_port = tag_address[next_id]
 
         request_measurements(udp_socket, next_ip, next_port)

--- a/multitag_main/multitag_main.ino
+++ b/multitag_main/multitag_main.ino
@@ -68,7 +68,7 @@ Adafruit_SSD1306 display(SCREEN_WIDTH, SCREEN_HEIGHT, &Wire, OLED_RESET);
 /****** WIFI CONFIG ********/
 const char* ssid = "DCS";
 const char* password = "701BA2887E";
-const char* udpServerIP = "192.168.0.4";
+const char* udpServerIP = "192.168.0.3";
 const int udpServerPort = 12345;
 WiFiUDP udp;
 /**** JSON variables ********/
@@ -212,7 +212,7 @@ void display_uwb()
 
 //newRange callback
 void newRange()
-{
+  {
   int i;
 
   //index of this anchor, expecting values 1 to 4
@@ -221,7 +221,7 @@ void newRange()
   if (index > 0 && index < 5) {
     // note down how many anchors has transmitted their range
     numRangeTransmitted++;
-    Serial.println(millis() - last_anchor_update[index - 1]); //prints ranging period in ms
+//    Serial.println(millis() - last_anchor_update[index - 1]); //prints ranging period in ms
     last_anchor_update[index - 1] = millis();  //(-1) => array index
     float range = DW1000Ranging.getDistantDevice()->getRange();
     last_anchor_distance[index - 1] = range;
@@ -258,15 +258,15 @@ void newRange()
 
 void newDevice(DW1000Device *device)
 {
-  Serial.print("Device added: ");
-  Serial.println(device->getShortAddress(), HEX);
+//  Serial.print("Device added: ");
+//  Serial.println(device->getShortAddress(), HEX);
   numAnchors++;
 }
 
 void inactiveDevice(DW1000Device *device)
 {
-  Serial.print("delete inactive device: ");
-  Serial.println(device->getShortAddress(), HEX);
+//  Serial.print("delete inactive device: ");
+//  Serial.println(device->getShortAddress(), HEX);
   numAnchors--;
 }
 

--- a/multitag_main/multitag_main.ino
+++ b/multitag_main/multitag_main.ino
@@ -66,9 +66,9 @@ float last_anchor_distance[N_ANCHORS] = {0.0}; //most recent distance reports
 Adafruit_SSD1306 display(SCREEN_WIDTH, SCREEN_HEIGHT, &Wire, OLED_RESET);
 
 /****** WIFI CONFIG ********/
-const char* ssid = "DCS";
-const char* password = "701BA2887E";
-const char* udpServerIP = "192.168.0.5";
+const char* ssid = "PROTON";
+const char* password = "prot2001!";
+const char* udpServerIP = "192.168.1.115";
 const int udpServerPort = 12345;
 WiFiUDP udp;
 /**** JSON variables ********/
@@ -189,7 +189,7 @@ void loop() {
     DW1000Ranging.loop();
   }
   
-  if (millis() - tokenTime > TRANSMIT_WINDOW) // can add numRangeTransmitted == numAnchors here later
+  if (millis() - tokenTime > TRANSMIT_WINDOW && hasToken) // can add numRangeTransmitted == numAnchors here later
   {
     // Call createJsonPackage to populate the JSON document
     createJsonPackage(&jsonDoc, &measurements);
@@ -240,32 +240,6 @@ void newRange()
     last_anchor_distance[index - 1] = range;
     last_anchor_addr[index - 1] = addr;
   }
-
-#ifdef DEBUG_ANCHOR_ID
-  Serial.print(index); //anchor ID, raw range
-  Serial.print(" ");;
-  Serial.println(range);
-#endif
-  //check for four measurements within the last interval
-  int detected = 0;  //count anchors recently seen
-
-  for (i = 0; i < N_ANCHORS; i++) {
-
-    if (millis() - last_anchor_update[i] > ANCHOR_DISTANCE_EXPIRED) last_anchor_update[i] = 0; //not from this one
-    if (last_anchor_update[i] > 0) detected++;
-  }
-  if ( (detected == N_ANCHORS)) { //four recent measurements
-
-#ifdef DEBUG_DISTANCES
-    // print distance and age of measurement
-    uint32_t current_time = millis();
-    for (i = 0; i < N_ANCHORS; i++) {
-      Serial.print(last_anchor_distance[i]);
-      Serial.print("\t");
-      Serial.println(current_time - last_anchor_update[i]); //age in millis
-    }
-#endif
-  }
 }  //end newRange
 
 void newDevice(DW1000Device *device)
@@ -306,4 +280,5 @@ void transmitJsonPackage(DynamicJsonDocument *jsonDoc, WiFiUDP &udp) {
   udp.beginPacket(udpServerIP, udpServerPort);
   udp.print(jsonStr);
   udp.endPacket();
+  udp.flush();
 }

--- a/multitag_main/multitag_main.ino
+++ b/multitag_main/multitag_main.ino
@@ -68,7 +68,7 @@ Adafruit_SSD1306 display(SCREEN_WIDTH, SCREEN_HEIGHT, &Wire, OLED_RESET);
 /****** WIFI CONFIG ********/
 const char* ssid = "DCS";
 const char* password = "701BA2887E";
-const char* udpServerIP = "192.168.0.3";
+const char* udpServerIP = "192.168.0.5";
 const int udpServerPort = 12345;
 WiFiUDP udp;
 /**** JSON variables ********/
@@ -109,8 +109,6 @@ void setup() {
   DW1000Ranging.attachNewDevice(newDevice);
   DW1000Ranging.attachInactiveDevice(inactiveDevice);
 
-  // Setup jsonDoc
-  DynamicJsonDocument jsonDoc(192);
   // start as tag, do not assign random short address
   //  DW1000Ranging.startAsTag(tag_addr, DW1000.MODE_LONGDATA_RANGE_LOWPOWER, false);
   //  DW1000Ranging.startAsTag(tag_addr, DW1000.MODE_SHORTDATA_FAST_LOWPOWER, false);  // range 7 m  smart power 10 m

--- a/multitag_main/multitag_main.ino
+++ b/multitag_main/multitag_main.ino
@@ -158,9 +158,18 @@ unsigned long lastDisplayTime = 0;
 // UDP read buffer
 char packetBuffer[2] = "";
 
+// 1 to indicate that it can run ranging
+// 0 to not run ranging
+uint8 hasToken = 0;
+
 void loop() {
   // put your main code here, to run repeatedly:
-  // if there's data available, read then get measurements
+
+  // if parsePacket > 0, then we have token
+
+  // run ranging if hasToken = 1
+
+  // send measurements if token has expired
   int packetSize = udp.parsePacket();
   if(packetSize){
     int len = udp.read(packetBuffer, 2);

--- a/multitag_main/multitag_main.ino
+++ b/multitag_main/multitag_main.ino
@@ -158,7 +158,7 @@ unsigned long lastTransmissionTime = 0;
 unsigned long lastDisplayTime = 0;
 
 // UDP read buffer
-char packetBuffer[2];
+char packetBuffer[2] = "";
 
 void loop() {
   // put your main code here, to run repeatedly:
@@ -167,7 +167,7 @@ void loop() {
   if(packetSize){
     int len = udp.read(packetBuffer, 2);
     if (len > 0) {
-      packetBuffer[len] = 0;
+      udp.flush(); // flush the buffer before next loop (just in case)
     }
     // reset number of anchors that transmitted its range
     numRangeTransmitted = 0;

--- a/tag_main/tag_main.ino
+++ b/tag_main/tag_main.ino
@@ -10,11 +10,11 @@
 #include "DW1000.h"
 
 /******** SETTINGS *********/
-#define TAG1  // use this to select the tag
-// #define TAG2
+//#define TAG1  // use this to select the tag
+#define TAG2
 // #define TAG3
-//#define MULTI_TAG
- #define SINGLE_TAG
+#define MULTI_TAG
+//#define SINGLE_TAG
 #define TRANSMIT_WINDOW 125
 
 /******** PIN DEFINITIONS *************/
@@ -77,7 +77,7 @@ Adafruit_SSD1306 display(SCREEN_WIDTH, SCREEN_HEIGHT, &Wire, OLED_RESET);
 /****** WIFI CONFIG ********/
 const char* ssid = "FibreStream 19322 - 2.4";
 const char* password = "roseleaf58";
-const char* udpServerIP = "192.168.0.242";
+const char* udpServerIP = "192.168.0.212";
 const int udpServerPort = 12345;
 WiFiUDP udp;
 /**** JSON variables ********/
@@ -156,10 +156,10 @@ void setup() {
   // send initial packet to GCS. (doesn't matter what is sent, as only the IP and port is needed)
   
 //  // Call createJsonPackage to populate the JSON document
-//  createJsonPackage(&jsonDoc, &measurements);
+  createJsonPackage(&jsonDoc, &measurements);
 //  
 //  // Call transmitJsonPackage to send the UDP message
-//  transmitJsonPackage(&jsonDoc, udp);
+  transmitJsonPackage(&jsonDoc, udp);
 }
 
 unsigned long lastTransmissionTime = 0;

--- a/tag_main/tag_main.ino
+++ b/tag_main/tag_main.ino
@@ -13,8 +13,8 @@
 #define TAG1  // use this to select the tag
 // #define TAG2
 // #define TAG3
-#define MULTI_TAG
-// #define SINGLE_TAG
+//#define MULTI_TAG
+ #define SINGLE_TAG
 #define TRANSMIT_WINDOW 125
 
 /******** PIN DEFINITIONS *************/
@@ -75,9 +75,9 @@ float filtered_anchor_distance[N_ANCHORS] = {0.0}; //most recent distance report
 Adafruit_SSD1306 display(SCREEN_WIDTH, SCREEN_HEIGHT, &Wire, OLED_RESET);
 
 /****** WIFI CONFIG ********/
-const char* ssid = "Drone Control Station";
-const char* password = "701BA2887E";
-const char* udpServerIP = "192.168.0.4";
+const char* ssid = "FibreStream 19322 - 2.4";
+const char* password = "roseleaf58";
+const char* udpServerIP = "192.168.0.242";
 const int udpServerPort = 12345;
 WiFiUDP udp;
 /**** JSON variables ********/
@@ -155,11 +155,11 @@ void setup() {
 
   // send initial packet to GCS. (doesn't matter what is sent, as only the IP and port is needed)
   
-  // Call createJsonPackage to populate the JSON document
-  createJsonPackage(&jsonDoc, &measurements);
-  
-  // Call transmitJsonPackage to send the UDP message
-  transmitJsonPackage(&jsonDoc, udp);
+//  // Call createJsonPackage to populate the JSON document
+//  createJsonPackage(&jsonDoc, &measurements);
+//  
+//  // Call transmitJsonPackage to send the UDP message
+//  transmitJsonPackage(&jsonDoc, udp);
 }
 
 unsigned long lastTransmissionTime = 0;
@@ -175,7 +175,7 @@ void loop() {
   // if there's data available, read then get measurements
   int packetSize = udp.parsePacket();
   if(packetSize){
-    int len = Udp.read(packetBuffer, 2);
+    int len = udp.read(packetBuffer, 2);
     if (len > 0) {
       packetBuffer[len] = 0;
     }

--- a/tag_main/tag_main.ino
+++ b/tag_main/tag_main.ino
@@ -15,6 +15,7 @@
 // #define TAG3
 #define MULTI_TAG
 // #define SINGLE_TAG
+#define TRANSMIT_WINDOW 125
 
 /******** PIN DEFINITIONS *************/
 #define SPI_SCK 18
@@ -179,7 +180,10 @@ void loop() {
       packetBuffer[len] = 0;
     }
     // get measurements
-    DW1000Ranging.loop();
+    unsigned long start_time = millis();
+
+    while(millis() - start_time < TRANSMIT_WINDOW)
+      DW1000Ranging.loop();
 
     // Call createJsonPackage to populate the JSON document
     createJsonPackage(&jsonDoc, &measurements);

--- a/tag_main/tag_main.ino
+++ b/tag_main/tag_main.ino
@@ -67,11 +67,11 @@ Adafruit_SSD1306 display(SCREEN_WIDTH, SCREEN_HEIGHT, &Wire, OLED_RESET);
 /****** WIFI CONFIG ********/
 const char* ssid = "DCS";
 const char* password = "701BA2887E";
-const char* udpServerIP = "192.168.0.4";
+const char* udpServerIP = "192.168.0.3";
 const int udpServerPort = 12345;
 WiFiUDP udp;
 /**** JSON variables ********/
-DynamicJsonDocument jsonDoc(192);
+DynamicJsonDocument jsonDoc(256);
 JsonObject measurements = jsonDoc.createNestedObject("measurements");
 
 void setup() {
@@ -104,8 +104,6 @@ void setup() {
   DW1000Ranging.attachNewDevice(newDevice);
   DW1000Ranging.attachInactiveDevice(inactiveDevice);
 
-  // Setup jsonDoc
-  DynamicJsonDocument jsonDoc(192);
   // start as tag, do not assign random short address
   //  DW1000Ranging.startAsTag(tag_addr, DW1000.MODE_LONGDATA_RANGE_LOWPOWER, false);
   //  DW1000Ranging.startAsTag(tag_addr, DW1000.MODE_SHORTDATA_FAST_LOWPOWER, false);  // range 7 m  smart power 10 m
@@ -193,7 +191,7 @@ void newRange()
   uint16_t addr = DW1000Ranging.getDistantDevice()->getShortAddress();
   int index = addr & 0x07; //expect devices 1 to 7
   if (index > 0 && index < 5) {
-    Serial.println(millis() - last_anchor_update[index - 1]); //prints ranging period in ms
+    // Serial.println(millis() - last_anchor_update[index - 1]); //prints ranging period in ms
     last_anchor_update[index - 1] = millis();  //(-1) => array index
     float range = DW1000Ranging.getDistantDevice()->getRange();
     last_anchor_distance[index - 1] = range;
@@ -230,14 +228,14 @@ void newRange()
 
 void newDevice(DW1000Device *device)
 {
-  Serial.print("Device added: ");
-  Serial.println(device->getShortAddress(), HEX);
+//  Serial.print("Device added: ");
+//  Serial.println(device->getShortAddress(), HEX);
 }
 
 void inactiveDevice(DW1000Device *device)
 {
-  Serial.print("delete inactive device: ");
-  Serial.println(device->getShortAddress(), HEX);
+//  Serial.print("delete inactive device: ");
+//  Serial.println(device->getShortAddress(), HEX);
 }
 
 

--- a/tag_main/tag_main.ino
+++ b/tag_main/tag_main.ino
@@ -10,11 +10,11 @@
 #include "DW1000.h"
 
 /******** SETTINGS *********/
-//#define TAG1  // use this to select the tag
-#define TAG2
+#define TAG1  // use this to select the tag
+// #define TAG2
 // #define TAG3
-#define MULTI_TAG
-//#define SINGLE_TAG
+// #define MULTI_TAG
+#define SINGLE_TAG
 #define TRANSMIT_WINDOW 100
 
 /******** PIN DEFINITIONS *************/
@@ -77,7 +77,7 @@ Adafruit_SSD1306 display(SCREEN_WIDTH, SCREEN_HEIGHT, &Wire, OLED_RESET);
 /****** WIFI CONFIG ********/
 const char* ssid = "DCS";
 const char* password = "701BA2887E";
-const char* udpServerIP = "192.168.0.3";
+const char* udpServerIP = "192.168.0.4";
 const int udpServerPort = 12345;
 WiFiUDP udp;
 /**** JSON variables ********/
@@ -106,7 +106,7 @@ void setup() {
   display.setTextColor(SSD1306_WHITE); // Draw white text
   display.setCursor(0, 0);     // Start at top-left corner
 
-  display.println("UWB tag ");
+  display.println("UWB tag");
   display.display();
 
   //initialize configuration
@@ -274,6 +274,8 @@ void newRange()
     //movingAverage(index - 1, range); // update filtered data
     //if (range < 0.0 || range > 30.0) last_anchor_update[index - 1] = 0;  //sanity check, ignore this measurement
   }
+  // note down how many anchors has transmitted their range
+  numRangeTransmitted++;
 
 #ifdef DEBUG_ANCHOR_ID
   Serial.print(index); //anchor ID, raw range
@@ -299,9 +301,6 @@ void newRange()
       Serial.println(current_time - last_anchor_update[i]); //age in millis
     }
 #endif
-  
-  // note down how many anchors has transmitted their range
-  numRangeTransmitted++;
   }
 }  //end newRange
 

--- a/udp_server.py
+++ b/udp_server.py
@@ -1,7 +1,7 @@
 import socket
 
 # Define the UDP server's IP address and port
-server_ip = "192.168.0.219"  # Listen on all available network interfaces
+server_ip = "192.168.0.212"  # Listen on all available network interfaces
 server_port = 12345  # Replace with the port you want to listen on
 
 # Create a UDP socket


### PR DESCRIPTION
Added simple multitag based on centralized initiator device scheduling tag ranging, based on Time Division Multiple Access (TDMA) protocol.

Files:
- multitag_control_server.py:
  - prototype server that handles multi tagging.
  - tags send initial packet to register it with the server
  - server prompts next tag to initiate sync once it receives another packet.
- tag_main.ino
  - only run ranging.loop if it gets a udp packet from server
  - added #define macros to switch between single/multi tag configuration.